### PR TITLE
Crypto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 *.d
 build
 downloads/*
+crypto/*.crt
+crypto/*.srl
+crypto/*.key
+crypto/*.csr

--- a/crypto/generate-ca.sh
+++ b/crypto/generate-ca.sh
@@ -1,0 +1,2 @@
+openssl genrsa -out ca.key 4096
+openssl req -x509 -new -nodes -key ca.key -sha256 -days 365 -out ca.crt

--- a/crypto/generate-user.sh
+++ b/crypto/generate-user.sh
@@ -1,0 +1,2 @@
+openssl genrsa -out user.key 2048
+openssl req -new -key user.key -out user.csr

--- a/makefile
+++ b/makefile
@@ -7,11 +7,12 @@ ifeq ($(origin CC),default)
 endif
 
 CFLAGS ?= -O2
+LDFLAGS ?= -lssl -lcrypto
 OUT_O_DIR ?= build
 SRC = ./source
 ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
-CSRC = source/main.c source/message.c source/user.c source/log.c source/serialization.c
+CSRC = source/main.c source/message.c source/user.c source/log.c source/serialization.c source/crypto.c
 
 # reproducing source tree in object tree
 COBJ := $(addprefix $(OUT_O_DIR)/,$(CSRC:.c=.o))

--- a/source/crypto.c
+++ b/source/crypto.c
@@ -1,0 +1,103 @@
+#include "crypto.h"
+#include "log.h"
+
+#include <openssl/asn1.h>
+#include <openssl/crypto.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+#include <openssl/sha.h>
+#include <openssl/ssl.h>
+#include <openssl/types.h>
+#include <openssl/x509.h>
+
+#include <stdio.h>
+
+void initialize_SSL() {
+  SSL_load_error_strings();
+  SSL_library_init();
+  OpenSSL_add_all_algorithms();
+}
+
+void destroy_SSL() {
+  ERR_free_strings();
+  EVP_cleanup();
+}
+
+// Extracts the user's uuid from the X509 certificate.
+uint32_t get_user_uuid_from_cert() {
+  FILE *fp = fopen("crypto/user.crt", "r");
+  if (!fp) {
+    print_error("Failed to open certificate file to get uuid");
+    return 0;
+  }
+  X509 *cert = PEM_read_X509(fp, NULL, NULL, NULL);
+  fclose(fp);
+  if (cert == NULL) {
+    print_error("Failed to read certificate to get uuid");
+    return 0;
+  }
+
+  ASN1_INTEGER *serial = X509_get_serialNumber(cert);
+  unsigned char *serial_buf = NULL;
+  int serial_len = i2d_ASN1_INTEGER(serial, &serial_buf);
+  if (serial_len <= 0) {
+    X509_free(cert);
+    print_error("Failed to encode serial number to get uuid");
+    return 0;
+  }
+
+  unsigned char hash[SHA256_DIGEST_LENGTH];
+  SHA256(serial_buf, serial_len, hash);
+
+  OPENSSL_free(serial_buf);
+  X509_free(cert);
+
+  // big-endian
+  uint32_t uuid = (hash[0] << 24) | (hash[1] << 16) | (hash[2] << 8) | hash[3];
+  return uuid;
+}
+
+// Checks the user certificate in crypto/user.crt and crypto/ca.crt
+int verify_user_certificate() {
+  FILE *file = NULL;
+
+  file = fopen("crypto/user.crt", "r");
+  if (file == NULL) {
+    print_error("Failed to open user.crt");
+    return -1;
+  }
+  X509 *user_cert = PEM_read_X509(file, NULL, NULL, NULL);
+  fclose(file);
+  if (user_cert == NULL) {
+    print_error("Failed to read user.crt");
+    return -1;
+  }
+  X509_STORE *store = NULL;
+  store = X509_STORE_new();
+  if (store == NULL) {
+    print_error("Failed to create a store");
+    return -1;
+  }
+  if (X509_STORE_load_locations(store, "crypto/ca.crt", NULL) != 1) {
+    print_error("Failed to load store ca.crt");
+    return -1;
+  }
+  X509_STORE_CTX *context = NULL;
+  context = X509_STORE_CTX_new();
+  if (context == NULL) {
+    print_error("Failed to create a context");
+    return -1;
+  }
+  if (X509_STORE_CTX_init(context, store, user_cert, NULL) != 1) {
+    print_error("Failed to init context store");
+    return -1;
+  }
+  int result = 0;
+  result = X509_verify_cert(context);
+
+  X509_STORE_CTX_free(context);
+  X509_STORE_free(store);
+  X509_free(user_cert);
+  return result == 1 ? 1 : -1;
+}

--- a/source/crypto.h
+++ b/source/crypto.h
@@ -1,0 +1,11 @@
+#ifndef CRYPTO_H
+#define CRYPTO_H
+
+#include <stdint.h>
+
+void initialize_SSL();
+void destroy_SSL();
+int verify_user_certificate();
+uint32_t get_user_uuid_from_cert();
+
+#endif

--- a/source/message.h
+++ b/source/message.h
@@ -3,6 +3,8 @@
 
 #include "user.h"
 
+#include <openssl/types.h>
+
 #include <stdint.h>
 
 #define MESSAGE_TEXT_LENGTH 8192
@@ -27,10 +29,9 @@ enum MESSAGE_TYPE {
 typedef struct {
   uint32_t sender_uuid;
   char sender_name[USER_NAME_SIZE];
-  uint32_t room; // TODO: Rename it. It's not a room anymore. It's like context_value now.
-                 // MESSAGE_TEXT use it?
-                 // MESSAGE_SYSTEM_ uses it as user.port
-                 // MESSAGE_FILE_ uses it as buffer size.
+  uint32_t room; // TODO: Rename it. It's not a room anymore. It's like
+                 // context_value now. MESSAGE_TEXT use it? MESSAGE_SYSTEM_ uses
+                 // it as user.port MESSAGE_FILE_ uses it as buffer size.
   uint32_t type;
   uint32_t time;
   char text[MESSAGE_TEXT_LENGTH];
@@ -42,6 +43,7 @@ void send_private_file(User *receiver, User *me, char *path);
 
 void get_file(Message *message);
 int get_message(Message *message, int sockfd);
+int get_ssl_message(Message *message, SSL *ssl);
 
 void set_should_send_file(int value);
 


### PR DESCRIPTION
## What added

### Crypto.h/Crypto.c

#### Functions:
-  `verify_user_certificate` - Now, in order to enter the chat, you need to have a signed and up-to-date certificate, as well as its affiliation with the certification authority.
- `get_user_uuid_from_cert` - Now, we have an almost guaranteed unique uuid for each user, while this uuid is saved and extracted from the user's certificate, which guarantees its immutability from session to session.

### Message.c/Message.h

#### Functions:
- `send_private_message` - The function now establishes a TLS connection with the recipient user by creating a new SSL context and performing a mutual TLS handshake. This ensures both client and server authenticate each other using their certificates.
- `get_ssl_message` - function reads a message from an established TLS connection.

### User.c
- `listen_other_users_tcp` - This function now runs a TCP server socket that listens for incoming TLS connections from other users, performs mutual certificate verification. And `signal(SIGPIPE, SIG_IGN);` ignores `SIGPIPE` signals to prevent the program from crashing if a socket is closed abruptly during a write operation. [more](https://stackoverflow.com/questions/33154547/thrift-random-crashes-on-ssl-accept)

### Tests

I tested it using different terminals, my laptop, and also checked situations where users have different CA, everything seems to be working correctly.