### PR TITLE
Test-Coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,7 @@ crypto/*.crt
 crypto/*.srl
 crypto/*.key
 crypto/*.csr
+*.info
 .cache
 compile_commands.json
+coverage-report

--- a/makefile
+++ b/makefile
@@ -1,5 +1,13 @@
 # make OUT_O_DIR=debug CC=clang CFLAGS="-g -O0"
 # make
+# make test
+# ******
+# lcov:
+# make coverage
+# lcov --capture --directory build --output-file coverage.info
+# lcov --remove coverage.info 'thirdparty/*' --output-file coverage.info
+# genhtml coverage.info --output-directory coverage-report
+# ******
 # make clean
 
 ifeq ($(origin CC),default)
@@ -10,12 +18,16 @@ CFLAGS ?= -O2 -Ithirdparty
 LDFLAGS ?= -lssl -lcrypto
 OUT_O_DIR ?= build
 SRC = ./source
+TEST_DIR = ./tests
 ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 CSRC = source/main.c source/message.c source/user.c source/log.c source/serialization.c source/crypto.c source/crc.c thirdparty/cJSON/cJSON.c
 
+TEST_SRC = tests/test_main.c tests/test_serialization.c
+
 # reproducing source tree in object tree
 COBJ := $(addprefix $(OUT_O_DIR)/,$(CSRC:.c=.o))
+TEST_OBJ = $(addprefix $(OUT_O_DIR)/,$(TEST_SRC:.c=.o))
 DEPS = $(COBJ:.o=.d)
 
 .PHONY: all
@@ -33,9 +45,28 @@ $(DEPS) : $(OUT_O_DIR)/%.d : %.c
 	@mkdir -p $(@D)
 	$(CC) -E $(CFLAGS) $< -MM -MT $(@:.d=.o) > $@
 
+.PHONY: test
+test: $(OUT_O_DIR)/test.x
+	./$(OUT_O_DIR)/test.x
+
+$(OUT_O_DIR)/test.x: $(TEST_OBJ) $(filter-out $(OUT_O_DIR)/source/main.o,$(COBJ))
+	@mkdir -p $(@D)
+	$(CC) $^ -o $@ $(LDFLAGS)
+
+$(OUT_O_DIR)/%.o : %.c
+	@mkdir -p $(@D)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+.PHONY: coverage
+coverage: CFLAGS += -O0 -g -fprofile-arcs -ftest-coverage -Ithirdparty
+coverage: LDFLAGS += -fprofile-arcs -lssl -lcrypto
+coverage: test
+
 .PHONY: clean
 clean:
-	rm -rf $(COBJ) $(DEPS) $(OUT_O_DIR)/*.x $(OUT_O_DIR)/*.log
+	rm -rf $(COBJ) $(DEPS) $(TEST_OBJ) $(OUT_O_DIR)/*.x $(OUT_O_DIR)/*.log
+	find $(OUT_O_DIR) -name '*.gcda' -delete
+	find $(OUT_O_DIR) -name '*.gcno' -delete
 
 # targets which we have no need to recollect deps
 NODEPS = clean

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+int test_serialization();
+
+int main() {
+  srand(time(NULL));
+  int failed = 0;
+  int success = 0;
+  if (test_serialization() < 0) {
+    fprintf(stderr, "Serialization failed\n");
+    failed++;
+  } else {
+    success++;
+  }
+  fprintf(stderr, "%d - Success\n%d - Failed\n", success, failed);
+}

--- a/tests/test_serialization.c
+++ b/tests/test_serialization.c
@@ -1,0 +1,73 @@
+#include "../source/serialization.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define NUMBER_OF_TESTS 100
+
+static inline void rand_str(char *dest, size_t length);
+
+int test_serialization() {
+  int success = 1;
+  Message before_message;
+  Message after_message;
+
+  for (int i = 0; i < NUMBER_OF_TESTS; ++i) {
+    before_message.context_value = rand();
+    before_message.sender_uuid = rand();
+    before_message.time = rand();
+    before_message.type = rand();
+    rand_str(before_message.text, MESSAGE_TEXT_LENGTH);
+    rand_str(before_message.sender_name, USER_NAME_SIZE);
+
+    unsigned char buffer[sizeof(before_message)];
+    serialize_message(&before_message, buffer);
+    deserialize_message(&after_message, buffer);
+    if (before_message.context_value != after_message.context_value) {
+      fprintf(stderr, "context_value: before %d after %d\n",
+              before_message.context_value, after_message.context_value);
+      return -1;
+    }
+    if (before_message.sender_uuid != after_message.sender_uuid) {
+      fprintf(stderr, "sender_uuid: before %d after %d\n",
+              before_message.sender_uuid, after_message.sender_uuid);
+      return -1;
+    }
+    if (before_message.time != after_message.time) {
+      fprintf(stderr, "time: before %d after %d\n", before_message.time,
+              after_message.time);
+      return -1;
+    }
+    if (before_message.type != after_message.type) {
+      fprintf(stderr, "type: before %d after %d\n", before_message.type,
+              after_message.type);
+      return -1;
+    }
+    if (strncmp(before_message.text, after_message.text, MESSAGE_TEXT_LENGTH) !=
+        0) {
+      fprintf(stderr, "text: before %s after %s\n", before_message.text,
+              after_message.text);
+      return -1;
+    }
+    if (strncmp(before_message.sender_name, after_message.sender_name,
+                USER_NAME_SIZE) != 0) {
+      fprintf(stderr, "name: before %s after %s\n", before_message.sender_name,
+              after_message.sender_name);
+      return -1;
+    }
+  }
+  return success;
+}
+
+void rand_str(char *dest, size_t length) {
+  char charset[] = "0123456789"
+                   "abcdefghijklmnopqrstuvwxyz"
+                   "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+  while (length-- > 1) {
+    size_t index = (double)rand() / RAND_MAX * (sizeof charset - 1);
+    *dest++ = charset[index];
+  }
+  *dest = '\0';
+}


### PR DESCRIPTION
## What added

### test_serialization.c

Added message serialization testing with automatic random tests.

### makefile

New targets have also been added to make:
- `make test` - Compiles and runs tests.
- `make coverage` - Compiles with special flags `fprofile-arcs` `ftest-coverage`.

### Results

If we run the following commands:
```cmd
make coverage
lcov --capture --directory build --output-file coverage.info
lcov --remove coverage.info 'thirdparty/*' --output-file coverage.info
genhtml coverage.info --output-directory coverage-report
firefox coverage-report/index.html
```
We will get the following results:
<img width="1718" height="406" alt="image" src="https://github.com/user-attachments/assets/ccb40314-e72f-4754-ae6f-b15a195cc7d5" />

It's not much, but it's better than nothing.